### PR TITLE
Remove text shadow from body styles

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -30,7 +30,6 @@ body {
 	background-color: #16191c;
 	color: #fcfcfc;
 	font-family: Arial, Helvetica, sans-serif;
-	text-shadow: rgb(0, 0, 0) 0px 0px 1.16667px !important;
 	// ion variables override
 	--ion-background-color: #16191c;
 	--ion-text-color: #fcfcfc;


### PR DESCRIPTION
This css rule should be removed, it usually applies to black-text on white background. No needed on the current theme.