### PR TITLE
feat(identity): enrich profile UI from Nostr kind0 metadata

### DIFF
--- a/src/Components/NavigationMenu/NavMenuHeader.tsx
+++ b/src/Components/NavigationMenu/NavMenuHeader.tsx
@@ -32,7 +32,8 @@ export const NavMenuHeader: React.FC = () => {
 		{ skip: !activeHex }
 	);
 
-	const displayName = profile?.display_name || profile?.name || 'Anonymous';
+	const username = profile?.name ? `@${profile.name}` : '';
+	const displayName = profile?.display_name || username || 'Anonymous';
 	const npub = useMemo(() => (activeHex ? nip19.npubEncode(activeHex) : ''), [activeHex]);
 	const img = profile?.picture;
 
@@ -77,6 +78,11 @@ export const NavMenuHeader: React.FC = () => {
 						) : (
 							<>
 								<h2 className="text-high" style={{ margin: 0 }}>{displayName}</h2>
+								{username && username !== displayName && (
+									<IonNote style={{ display: 'block', "--color": "var(--ion-text-color-step-450)" }}>
+										{username}
+									</IonNote>
+								)}
 								<IonNote style={{ display: 'block', "--color": "var(--ion-text-color-step-450)" }}>{truncate(npub)}</IonNote>
 							</>
 						)}

--- a/src/Pages/CreateIdentity/CreateKeysIdentity.tsx
+++ b/src/Pages/CreateIdentity/CreateKeysIdentity.tsx
@@ -106,7 +106,7 @@ const CreateKeysIdentityPage: React.FC<RouteComponentProps> = (_props: RouteComp
 			privkey: privateKey,
 			pubkey: pubkey,
 			relays: [defaultRelay],
-			label: "New Sanctum Identity",
+			label: "New Keys Identity",
 			createdAt: Date.now()
 		}
 

--- a/src/Pages/CreateIdentity/Identities/index.tsx
+++ b/src/Pages/CreateIdentity/Identities/index.tsx
@@ -113,7 +113,8 @@ const IdentityRow
 		);
 		const isActive = activeHex === pubkeyHex;
 
-		const displayName = profile?.display_name || profile?.name || "Anonymous"
+		const username = profile?.name ? `@${profile.name}` : "";
+		const displayName = profile?.display_name || username || "Anonymous";
 		const picture = profile?.picture || robo(pubkeyHex);
 		const npub = nip19.npubEncode(pubkeyHex);
 
@@ -147,6 +148,11 @@ const IdentityRow
 					<IonText className="text-high text-md">
 						{displayName}
 					</IonText>
+					{username && username !== displayName && (
+						<IonText className="text-medium" style={{ display: "block", marginTop: 2 }}>
+							{username}
+						</IonText>
+					)}
 
 					<IonText className="ion-margin-top text-medium code-string" style={{ display: "block" }}>
 						{truncateTextMiddle(npub)}

--- a/src/Pages/CreateIdentity/IdentityOverview.tsx
+++ b/src/Pages/CreateIdentity/IdentityOverview.tsx
@@ -67,7 +67,11 @@ const IdentityOverviewPage = () => {
 	);
 
 	const displayName = useMemo(
-		() => profile?.display_name || profile?.name || "Anonymous",
+		() => profile?.display_name || (profile?.name ? `@${profile.name}` : "Anonymous"),
+		[profile]
+	);
+	const username = useMemo(
+		() => profile?.name ? `@${profile.name}` : null,
 		[profile]
 	);
 	const picture = profile?.picture || (activeHex ? `https://robohash.org/${activeHex}.png?bgset=bg1` : "");
@@ -182,6 +186,16 @@ const IdentityOverviewPage = () => {
 			<IonContent className="ion-padding">
 				<div className="page-outer">
 					<div className="page-body">
+						{profile?.banner && (
+							<section className="main-block mb-5">
+								<img
+									src={profile.banner}
+									alt=""
+									referrerPolicy="no-referrer"
+									style={{ width: "100%", maxHeight: 180, objectFit: "cover", borderRadius: 12 }}
+								/>
+							</section>
+						)}
 
 						<section className="hero-block flex-row gap-4">
 							<div className="flex items-center flex-grow  justify-center max-w-[80px] lg:max-w-[100px]">
@@ -211,6 +225,11 @@ const IdentityOverviewPage = () => {
 								<div className="text-high text-left font-semibold text-xl">
 									{displayName}
 								</div>
+								{username && username !== displayName && (
+									<div className="text-medium text-left text-md mt-1">
+										{username}
+									</div>
+								)}
 
 								<div className="flex flex-row flex-wrap items-center justify-center gap-2 mt-1">
 									<IonText className="text-medium ion-text-wrap text-weight-medium ion-text-justify code-string">
@@ -255,6 +274,16 @@ const IdentityOverviewPage = () => {
 													relays: adminSource.relays,
 												})
 											)}
+										</dd>
+									</>
+								)}
+								{profile?.lud16 && (
+									<>
+										<dt className="text-high text-lg text-center sm:text-left sm:pr-2">
+											Lightning address:
+										</dt>
+										<dd className="text-low pt-1 leading-snug break-all text-center sm:text-left">
+											{profile.lud16}
 										</dd>
 									</>
 								)}

--- a/src/State/api/api.ts
+++ b/src/State/api/api.ts
@@ -3,11 +3,15 @@ import { fetchNostrUserMetadataEvent } from "@/Api/nostrHandler";
 
 export type NostrProfile = {
 	pubkey: string;
+	username?: string;
 	name?: string;
 	display_name?: string;
 	picture?: string;
+	banner?: string;
 	about?: string;
 	nip05?: string;
+	lud16?: string;
+	lud06?: string;
 };
 
 export const appApi = createApi({
@@ -18,7 +22,14 @@ export const appApi = createApi({
 			queryFn: async ({ pubkey, relays }) => {
 				try {
 					const meta = await fetchNostrUserMetadataEvent(pubkey, relays);
-					return { data: JSON.parse(meta!.content!) ?? null };
+					if (!meta?.content) {
+						return { data: null };
+					}
+					const parsed = JSON.parse(meta.content) as Omit<NostrProfile, "pubkey"> | null;
+					if (!parsed || typeof parsed !== "object") {
+						return { data: null };
+					}
+					return { data: { pubkey, ...parsed } };
 				} catch (e: any) {
 					return { error: { status: 'CUSTOM_ERROR', error: e?.message ?? 'failed' } as any };
 				}


### PR DESCRIPTION
fixed #579 

**Summary**

- Added safer kind0 profile parsing in the API layer and expanded supported metadata fields (banner, lud16, lud06).
- Updated identity-related UI to clearly display Display Name and @username (when available).
- Fixed default label for key-based identity creation: "New Sanctum Identity" -> "New Keys Identity".