### PR TITLE
feat(invitations): add QR codes and one-time invite UI

### DIFF
--- a/src/Pages/Invitations/Invitations.scss
+++ b/src/Pages/Invitations/Invitations.scss
@@ -6,6 +6,38 @@
   margin-inline: auto;
   font-family: Montserrat;
 
+  .clipboard-copy {
+    width: fit-content;
+    margin-top: 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    position: relative;
+    box-sizing: border-box;
+    font-size: 22px;
+    font-family: Montserrat;
+    padding: 7px 16px;
+    $border: 1px;
+    color: #fff;
+    background: #16191c;
+    background-clip: padding-box;
+    border: solid $border transparent;
+    border-radius: 5px;
+
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: -1;
+      margin: -$border;
+      border-radius: 3px;
+      background: linear-gradient(150deg, #29abe2, #b0b0b0);
+    }
+  }
+
   &_title {
     font-size: 100%;
     text-align: center;
@@ -43,36 +75,14 @@
     }
 
     & > .clipboard-copy {
-      width: fit-content;
-      margin-top: 10px;
       align-self: end;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      position: relative;
-      box-sizing: border-box;
-      font-size: 22px;
-      font-family: Montserrat;
-      padding: 7px 16px;
-      $border: 1px;
-      color: #fff;
-      background: #16191c;
-      background-clip: padding-box;
-      border: solid $border transparent;
-      border-radius: 5px;
+    }
 
-      &:before {
-        content: "";
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        z-index: -1;
-        margin: -$border;
-        border-radius: 3px;
-        background: linear-gradient(150deg, #29abe2, #b0b0b0);
-      }
+    & > .qr-wrap {
+      margin-top: 20px;
+      max-width: min(280px, 90vw);
+      width: 100%;
+      margin-inline: auto;
     }
   }
 
@@ -87,6 +97,17 @@
       margin-block-end: 10px;
     }
 
+    & > .create-row {
+      margin-top: 8px;
+    }
+
+    & > .gift-note {
+      font-size: 12px;
+      color: #adadad;
+      margin-top: 16px;
+      text-align: center;
+    }
+
     & > .link-group {
       margin-top: 15px;
       display: flex;
@@ -95,11 +116,25 @@
 
       & > .content {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
+        flex-direction: column;
+        gap: 12px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+        &:last-child {
+          border-bottom: none;
+          padding-bottom: 0;
+        }
+
+        & > .row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        }
 
         & > .text {
-          width: 85%;
+          width: 100%;
           & > .link {
             font-size: 16px;
             color: #adadad;
@@ -117,8 +152,15 @@
           }
         }
 
-        & > .iconButton {
+        & > .qr-wrap {
+          max-width: min(240px, 85vw);
+          width: 100%;
+          margin-inline: auto;
+        }
+
+        & > .row .iconButton {
           cursor: pointer;
+          flex-shrink: 0;
           $border: 1px;
           background: #16191c;
           border: solid $border transparent;

--- a/src/Pages/Invitations/index.tsx
+++ b/src/Pages/Invitations/index.tsx
@@ -11,8 +11,7 @@ import { check, copyWhite } from "@/Assets/SvgIconLibrary";
 import { useAppSelector } from "@/State/store/hooks";
 import { selectHealthyNprofileViews } from "@/State/scoped/backups/sources/selectors";
 import { nip19 } from "nostr-tools";
-
-
+import QrCode from "@/Components/QrCode";
 
 
 const Invitations = () => {
@@ -54,9 +53,6 @@ const Invitations = () => {
 		}
 	}
 
-	console.log(WALLET_URL, import.meta.env.VITE_WALLET_URL)
-
-
 	const copyToClip = async (text: string) => {
 		await Clipboard.write({
 			string: text,
@@ -96,25 +92,6 @@ const Invitations = () => {
 		subNode: selectedSource.label,
 	} : null;
 
-	/*   const oneTimeLinks: OneTimeLink[] = [
-			{
-				link: "shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123...",
-				subNode: "01/01/2024 16:20 | steakhouse tip | 5000 sats",
-				statu: "usable",
-			},
-			{
-				link: "shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123...",
-				subNode: "01/01/2024 16:20 | steakhouse tip | 5000 sats",
-				statu: "expired",
-			},
-			{
-				link: "shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123shockwallet.app/invite/nprofile123...",
-				subNode: "01/01/2024 16:20 | steakhouse tip | 5000 sats",
-				statu: "expired",
-			},
-		]; */
-
-
 	const oneTimeLinksRender = useMemo(() => {
 		return (
 			<div className="link-group">
@@ -123,28 +100,34 @@ const Invitations = () => {
 						const link = `${WALLET_URL}/sources?addSource=${nprofile}&inviteToken=${inv.inviteToken}`
 						return (
 							<div key={inv.inviteToken} className="content">
-								<div className="text">
-									<div className="link">{link}</div>
-									<div className="subNode">{selectedSource?.label}</div>
+								<div className="row">
+									<div className="text">
+										<div className="link">{link}</div>
+										<div className="subNode">{selectedSource?.label}</div>
+									</div>
+									<button
+										type="button"
+										onClick={() => copyToClip(link)}
+										className="iconButton"
+										disabled={inv.used}
+									>
+										{inv.used ? (
+											check()
+										) : (
+											<span>{copyWhite()}</span>
+										)}
+									</button>
 								</div>
-								<button
-									onClick={() => copyToClip(link)}
-									className="iconButton"
-									disabled={inv.used}
-								>
-									{inv.used ? (
-										check()
-									) : (
-										<span>{copyWhite()}</span>
-									)}
-								</button>
+								<div className="qr-wrap">
+									<QrCode value={link} uppercase={false} />
+								</div>
 							</div>
 						)
 					})
 				}
 			</div>
 		)
-	}, [invitations.invitations])
+	}, [invitations.invitations, nprofile, selectedSource])
 
 	return (
 		<div className="Invitations">
@@ -164,30 +147,34 @@ const Invitations = () => {
 							</div>
 						</div>
 						<button
+							type="button"
 							onClick={() => copyToClip(reusableLink.link)}
 							className="clipboard-copy"
 						>
 							{copyWhite()}COPY
 						</button>
+						<div className="qr-wrap">
+							<QrCode value={reusableLink.link} uppercase={false} />
+						</div>
 					</>
 				}
 			</div>
 			<div className="Invitations_One-Time-Links">
 				<div className="title">One-Time Links</div>
-				<div className="content">
-					<div className="Gift" style={{ fontSize: "12px", paddingTop: "50px", textAlign: "center" }}>
-						Gift links coming soon.
+				{reusableLink && (
+					<div className="create-row">
+						<button
+							type="button"
+							onClick={() => newInviteLink()}
+							className="clipboard-copy"
+						>
+							Create one-time link
+						</button>
 					</div>
-				</div>
+				)}
+				{oneTimeLinksRender}
+				<div className="gift-note">Gift links coming soon.</div>
 			</div>
-			{/* <div className="Invitations_reusableLink">
-        <button
-          onClick={() => newInviteLink()}
-          className="clipboard-copy"
-        >
-          {Icons.copyWhite()}Create New
-        </button>
-      </div> */}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

Adds QR codes to the admin **Invite Links** (`/invitations`) screen so reusable and one-time invite URLs can be scanned as well as copied. Restores visibility of one-time invite links and a **Create one-time link** action; keeps the existing “Gift links coming soon” note.

Closes https://github.com/shocknet/wallet2/issues/581

## Changes

- **Reusable link:** show the same URL as today, plus a scannable QR (encoding preserves URL casing via `uppercase={false}` on `QrCode`).
- **One-time links:** render stored invitations with copy control and QR per row; add **Create one-time link** when an admin source is present.
- **Styles:** shared `.clipboard-copy` under `.Invitations`, QR wrappers (`max-width`), column layout for one-time rows, subtle separators, gift footnote.