### PR TITLE
Fix Metrics dashboard button label contrast

### DIFF
--- a/src/Pages/Metrics/metricsMain.tsx
+++ b/src/Pages/Metrics/metricsMain.tsx
@@ -357,7 +357,7 @@ const Dashboard = () => {
 								<div className={styles["between"]}>
 
 									<PeriodSelector period={period} offset={offset} setPeriod={setPeriod} resetOffset={() => setOffset(0)} prevOffset={prevOffset} nextOffset={nextOffset} />
-									<IonButton expand="block" fill="clear" color="light" routerLink="/metrics/manage" routerDirection="forward" className={classNames(styles["box"], styles["border"])}>
+									<IonButton expand="block" fill="clear" routerLink="/metrics/manage" routerDirection="forward" className={classNames(styles["box"], styles["border"], styles["dashboard-action-button"])}>
 										Manage
 									</IonButton>
 								</div>
@@ -488,12 +488,12 @@ const Dashboard = () => {
 								</div>
 							</div>
 							<div className={styles["section"]}>
-								<IonButton expand="block" fill="clear" color="light" routerLink="/metrics/swaps" routerDirection="forward" className={classNames(styles["box"], styles["border"])}>
+								<IonButton expand="block" fill="clear" routerLink="/metrics/swaps" routerDirection="forward" className={classNames(styles["box"], styles["border"], styles["dashboard-action-button"])}>
 									Swaps
 								</IonButton>
 							</div>
 							<div className={styles["section"]}>
-								<IonButton expand="block" fill="clear" color="light" routerLink="/metrics/assets-liabilities" routerDirection="forward" className={classNames(styles["box"], styles["border"])}>
+								<IonButton expand="block" fill="clear" routerLink="/metrics/assets-liabilities" routerDirection="forward" className={classNames(styles["box"], styles["border"], styles["dashboard-action-button"])}>
 									Assets & Liabilities
 								</IonButton>
 							</div>

--- a/src/Pages/Metrics/styles/index.module.scss
+++ b/src/Pages/Metrics/styles/index.module.scss
@@ -311,13 +311,20 @@
 				left: 1px;
 				right: 1px;
 				bottom: 1px;
-				background: #16191c;
+				background: var(--ion-background-color);
 				z-index: -1;
 				border-radius: 4px;
 			}
 		}
 	}
 
+}
+
+/* Ionic `color="light"` on clear buttons uses the light palette as label color; on dark
+   card chrome that becomes low-contrast. Tie label color to theme text instead. */
+.dashboard-action-button {
+	--color: var(--ion-text-color);
+	font-weight: 600;
 }
 
 .column {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Metrics main view used `IonButton` with `fill="clear"` and `color="light"`. In Ionic, that maps the button text color to the **light** palette (white in light mode, dark in dark mode), which clashed with the dark gradient-border card chrome—labels were effectively invisible in light theme.

## Changes

- Dropped `color="light"` on Manage / Swaps / Assets & Liabilities actions.
- Added a small `dashboard-action-button` class that sets `--color: var(--ion-text-color)` so labels follow the active theme.
- Swapped the hard-coded `#16191c` inner fill on `.border` for `var(--ion-background-color)` so the card matches light/dark backgrounds.

## Verification

- `npx vite build` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0e6cc72-e8dc-4aa8-81b9-8284df3362d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0e6cc72-e8dc-4aa8-81b9-8284df3362d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

