### PR TITLE
Fix channels UI avatars and add peer/channel buttons

### DIFF
--- a/src/Pages/Channels/Channels.scss
+++ b/src/Pages/Channels/Channels.scss
@@ -52,13 +52,22 @@
 
       & .avatar {
         display: flex;
-        gap: 5px;
+        gap: 8px;
         align-items: center;
+        min-width: 0;
         & > img {
           border-radius: 50%;
+          flex-shrink: 0;
+          width: 32px;
+          height: 32px;
+          object-fit: cover;
         }
         & > div {
           font-size: 12px;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
 
@@ -146,5 +155,19 @@
     font-style: italic;
     text-align: center;
     margin-block-end: 10px;
+  }
+
+  &_open-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-block: 8px 16px;
+
+    ion-button {
+      margin: 0;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: none;
+    }
   }
 }

--- a/src/Pages/Channels/OpenChannel.tsx
+++ b/src/Pages/Channels/OpenChannel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { IonButton } from "@ionic/react";
 import { getNostrClient } from "@/Api/nostr";
 import PromptForActionModal, { ActionType } from "../../Components/Modals/PromptForActionModal";
 import { toast } from "react-toastify";
@@ -58,10 +59,13 @@ export const OpenChannel = ({ adminSource }: { adminSource: NprofileView }) => {
 
 	return (
 		<div>
-			<div>
-				<button onClick={() => setOpenModal('addPeer')}>ADD PEER</button>
-				<button onClick={() => setOpenModal('openChannel')}>ADD CHANNEL</button>
-
+			<div className="Channels_open-actions">
+				<IonButton expand="block" onClick={() => setOpenModal("addPeer")}>
+					Add peer
+				</IonButton>
+				<IonButton expand="block" fill="outline" onClick={() => setOpenModal("openChannel")}>
+					Add channel
+				</IonButton>
 			</div>
 			{openModal === 'addPeer' && <PromptForActionModal title="Add Peer"
 				actionText="Add Peer"

--- a/src/Pages/Channels/index.tsx
+++ b/src/Pages/Channels/index.tsx
@@ -90,10 +90,11 @@ const Channels = () => {
 				if (c.remote_balance > max) {
 					max = c.remote_balance
 				}
+				const avatar = channelRoboAvatarUrl(c)
 				if (c.active) {
-					active.push({ avatar: "", id: i, name: c.label, localSatAmount: c.local_balance, RemoteSatAmount: c.remote_balance, channel: c })
+					active.push({ avatar, id: i, name: c.label, localSatAmount: c.local_balance, RemoteSatAmount: c.remote_balance, channel: c })
 				} else {
-					offline.push({ avatar: "", id: i, name: c.label, encumbered: c.local_balance, timeStamp: c.inactive_since_unix, subNode: "Initiate force-close", channel: c })
+					offline.push({ avatar, id: i, name: c.label, encumbered: c.local_balance, timeStamp: c.inactive_since_unix, subNode: "Initiate force-close", channel: c })
 				}
 			})
 			setMaxBalance(max);
@@ -167,10 +168,10 @@ const Channels = () => {
 											<div className="avatar">
 												<img
 													src={channel.avatar}
-													width={12}
-													height={12}
-													className=""
-													alt="avatar"
+													width={32}
+													height={32}
+													decoding="async"
+													alt=""
 												/>
 												<div>{channel.name}</div>
 											</div>
@@ -222,10 +223,10 @@ const Channels = () => {
 											<div className="avatar">
 												<img
 													src={channel.avatar}
-													width={12}
-													height={12}
-													className=""
-													alt="avatar"
+													width={32}
+													height={32}
+													decoding="async"
+													alt=""
 												/>
 												<div>{channel.name}</div>
 											</div>
@@ -298,6 +299,15 @@ const SatAmountBar: React.FC<ComponentProps> = ({
 		</div>
 	);
 };
+
+function channelRoboAvatarUrl(channel: OpenChannel): string {
+	const seed =
+		channel.channel_id?.trim() ||
+		channel.channel_point?.trim() ||
+		channel.label?.trim() ||
+		"channel"
+	return `https://robohash.org/${encodeURIComponent(seed)}.png?bgset=bg1`
+}
 
 const formatCryptoAmount = (amount: number): string => {
 	if (amount >= 1000000) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Avatars:** Channel rows were building `avatar: ""` and rendering a 12×12 `<img>`, which produced broken images and vertical alt text that broke the layout. Avatars now use a stable `robohash.org` URL derived from `channel_id`, then `channel_point`, then `label`, with 32×32 display size, `object-fit: cover`, and empty `alt` so no placeholder text appears if the image fails.
- **Labels:** Long channel labels get a single-line ellipsis in the avatar row so they do not wrap awkwardly.
- **Actions:** Replaced the unstyled "ADD PEER" / "ADD CHANNEL" native buttons with full-width `IonButton` controls (primary + outline) and scoped `.Channels_open-actions` styles consistent with the channels page spacing.

## Testing

- `npx eslint` on the touched Channels files (project-wide `npm run lint` has pre-existing failures).
- `npm run test.unit` currently fails in unrelated specs; no new failures attributable to these changes were isolated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4424f5fb-336d-490d-8392-840f31f5d50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4424f5fb-336d-490d-8392-840f31f5d50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

