### PR TITLE
Lightning.pub dashboard stylesheet and channels modal styling

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -167,6 +167,8 @@ input[type=number] {
 
 
 
+@import "./styles/shocknet-lnpub.scss";
+
 @import "./Pages/Loader/Loader.scss";
 
 

--- a/src/Components/Modals/Modal/Modal.style.tsx
+++ b/src/Components/Modals/Modal/Modal.style.tsx
@@ -28,19 +28,38 @@ export const Backdrop = styled.div`
   z-index: 500;
 `;
 
-export const StyledModal = styled.div`
+export const StyledModal = styled.div<{ $variant?: "default" | "lnpub" }>`
   width: 90%;
   max-width: 600px;
-  border: 1px solid #29abe2;
   font-family: Montserrat;
   padding: 25px 20px 25px 20px;
   text-align: center;
   z-index: 100;
   font-size: 20px;
-  background-color: var(--ion-color-light);
   margin: auto;
   border-radius: 5px;
   position: relative;
+
+  ${(p) =>
+		p.$variant === "lnpub"
+			? `
+    --lp-a: #ff8a00;
+    --lp-b: #f040f5;
+    --prod-gradient: linear-gradient(90deg, var(--lp-a), var(--lp-b));
+    border-radius: 12px;
+    padding: 22px 18px;
+    font-size: 16px;
+    color: var(--ion-text-color, #fcfcfc);
+    background: linear-gradient(var(--ion-background-color, #16191c), var(--ion-background-color, #16191c))
+        padding-box,
+      var(--prod-gradient) border-box;
+    border: 2px solid transparent;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  `
+			: `
+    border: 1px solid #29abe2;
+    background-color: var(--ion-color-light);
+  `}
 `;
 
 export const Header = styled.div`

--- a/src/Components/Modals/Modal/index.tsx
+++ b/src/Components/Modals/Modal/index.tsx
@@ -14,12 +14,17 @@ export const Modal: FunctionComponent<ModalProps> = ({
   isShown,
   hide,
   modalContent,
+  variant = "default",
 }) => {
   const modal = (
     <React.Fragment>
       <Backdrop id="backdrop-background" onClick={hide} onTouchEnd={hide} />
       <Wrapper>
-        <StyledModal>
+        <StyledModal
+          $variant={variant}
+          data-product={variant === "lnpub" ? "lnpub" : undefined}
+          data-theme={variant === "lnpub" ? "dark" : undefined}
+        >
           <Content>{modalContent}</Content>
         </StyledModal>
       </Wrapper>

--- a/src/Components/Modals/PromptForActionModal/index.tsx
+++ b/src/Components/Modals/PromptForActionModal/index.tsx
@@ -16,8 +16,20 @@ interface Props {
 	actionText: string;
 	jsx?: ReactNode;
 	blur?: boolean;
+	/** Lightning.pub metrics dashboard styling (modal shell + actions). */
+	variant?: "default" | "lnpub";
 }
-export default function PromptForActionModal({ descriptionText, action, title, actionType, closeModal, actionText, blur, jsx }: Props) {
+export default function PromptForActionModal({
+	descriptionText,
+	action,
+	title,
+	actionType,
+	closeModal,
+	actionText,
+	blur: _blur,
+	jsx,
+	variant = "default",
+}: Props) {
 
 	const handleConfirm = () => {
 		action();
@@ -25,7 +37,11 @@ export default function PromptForActionModal({ descriptionText, action, title, a
 	}
 
 	const modalContent = (
-		<div className={styles["container"]}>
+		<div
+			className={classNames(styles["container"], {
+				[styles["container--lnpub"]]: variant === "lnpub",
+			})}
+		>
 			<div className={styles["modal-header"]}>
 				{title}
 			</div>
@@ -53,5 +69,13 @@ export default function PromptForActionModal({ descriptionText, action, title, a
 		</div>
 	)
 
-	return <Modal isShown={true} hide={closeModal} modalContent={modalContent} headerText={''} />
+	return (
+		<Modal
+			isShown={true}
+			hide={closeModal}
+			modalContent={modalContent}
+			headerText=""
+			variant={variant === "lnpub" ? "lnpub" : "default"}
+		/>
+	);
 }

--- a/src/Components/Modals/PromptForActionModal/styles/index.module.scss
+++ b/src/Components/Modals/PromptForActionModal/styles/index.module.scss
@@ -1,5 +1,5 @@
-@import "/src/styles/modals.module";
-@import "/src/styles/buttons.module";
+@import "/src/styles/_modals.module";
+@import "/src/styles/_buttons.module";
 .container {
 	@include modal-wrapper;
 	.content-container {
@@ -36,6 +36,88 @@
 		}
 	}
 }
+
+.container--lnpub {
+	.modal-header {
+		position: relative;
+		font-size: 20px;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		margin-bottom: 6px;
+		padding-bottom: 14px;
+
+		&::after {
+			content: "";
+			position: absolute;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			height: 2px;
+			border-radius: 2px;
+			background: linear-gradient(90deg, var(--lp-a, #ff8a00), var(--lp-b, #f040f5));
+		}
+	}
+
+	.content-container {
+		padding-top: 8px;
+	}
+
+	.description {
+		text-align: left;
+		font-size: 14px;
+		line-height: 1.45;
+		color: color-mix(in srgb, var(--ion-text-color, #fff) 88%, transparent);
+	}
+
+	.action-buttons {
+		flex-direction: column-reverse;
+		gap: 10px;
+		margin-top: 4px;
+
+		.button {
+			width: 100%;
+			justify-content: center;
+			min-height: 44px;
+			border-radius: 10px;
+			font-weight: 600;
+			font-size: 15px;
+			text-transform: none;
+			transition: box-shadow 0.2s ease, filter 0.15s ease;
+		}
+
+		.cancel-button {
+			background: transparent;
+			border: 1px solid var(--lp-a, #ff8a00);
+			color: var(--lp-a, #ff8a00);
+		}
+
+		.cancel-button:hover {
+			box-shadow: 0 0 20px rgba(255, 138, 0, 0.22);
+		}
+
+		.normal {
+			background: linear-gradient(90deg, var(--lp-a, #ff8a00), var(--lp-b, #f040f5));
+			border: none;
+			color: #ffffff;
+		}
+
+		.normal:hover {
+			box-shadow: 0 0 20px rgba(255, 138, 0, 0.22);
+		}
+
+		.danger {
+			background: #f04437;
+			border: 1px solid #f04437;
+			color: #fff;
+		}
+
+		.danger:hover {
+			filter: brightness(1.06);
+			box-shadow: 0 0 16px rgba(240, 68, 55, 0.35);
+		}
+	}
+}
+
 .modal-wrapper {
 
 	&.blur {

--- a/src/Pages/Channels/Channels.scss
+++ b/src/Pages/Channels/Channels.scss
@@ -31,7 +31,7 @@
 
     & > .line {
       margin-block: 5px;
-      background: linear-gradient(60deg, #ff7700 0%, #c740c7 100%);
+      background: linear-gradient(90deg, var(--lp-a, #ff8a00), var(--lp-b, #f040f5));
       width: 100%;
       height: 1px;
       margin-inline: auto;
@@ -52,13 +52,22 @@
 
       & .avatar {
         display: flex;
-        gap: 5px;
+        gap: 8px;
         align-items: center;
+        min-width: 0;
         & > img {
           border-radius: 50%;
+          flex-shrink: 0;
+          width: 32px;
+          height: 32px;
+          object-fit: cover;
         }
         & > div {
           font-size: 12px;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
 
@@ -92,7 +101,7 @@
           gap: 5px;
 
           & > .sub-node {
-            color: #a012c7;
+            color: var(--lp-b, #f040f5);
             font-size: 11px;
             text-decoration: underline;
           }
@@ -146,5 +155,37 @@
     font-style: italic;
     text-align: center;
     margin-block-end: 10px;
+  }
+
+  &_open-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-block: 8px 16px;
+  }
+
+  &_error-callout {
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 12px;
+    margin-bottom: 12px;
+    color: var(--ion-text-color, #fcfcfc);
+  }
+
+  &_error-title {
+    font-weight: 700;
+    margin-bottom: 8px;
+  }
+
+  &_error-body {
+    opacity: 0.9;
+    margin-bottom: 12px;
+    font-size: 14px;
+  }
+
+  &_error-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 }

--- a/src/Pages/Channels/EditChannel.tsx
+++ b/src/Pages/Channels/EditChannel.tsx
@@ -74,75 +74,195 @@ export const EditChannel = ({ adminSource, selectedChannel, deselect }: { adminS
 	}
 
 	if (openModal === 'showPolicy') {
-		return <PromptForActionModal title="Channel Policy"
-			actionText="OK"
-			actionType={ActionType.NORMAL}
-			closeModal={() => { deselect() }}
-			action={() => { deselect() }}
-			jsx={<>
-				{selectedChannel.policy && <div>
-					<p>Base fee Msat: {selectedChannel.policy.base_fee_msat}</p>
-					<p>Fee rate Ppm: {selectedChannel.policy.fee_rate_ppm}</p>
-					<p>Max HTLC Msat: {selectedChannel.policy.max_htlc_msat}</p>
-					<p>Min HTLC Msat: {selectedChannel.policy.min_htlc_msat}</p>
-					<p>Time Lock Delta: {selectedChannel.policy.timelock_delta}</p>
-					<button onClick={e => { setOpenModal('updatePolocy') }}>EDIT POLICY</button>
-					<button onClick={e => { setOpenModal('closeChannel') }}>CLOSE CHANNEL</button>
-				</div>}
-				{!selectedChannel.policy && <div>No Policy found for channel</div>}
-			</>}
-		/>
+		return (
+			<PromptForActionModal
+				title="Channel Policy"
+				actionText="OK"
+				actionType={ActionType.NORMAL}
+				variant="lnpub"
+				closeModal={() => {
+					deselect();
+				}}
+				action={() => {
+					deselect();
+				}}
+				jsx={
+					<>
+						{selectedChannel.policy && (
+							<div className="lnpub-form-stack">
+								<p>Base fee (msat): {selectedChannel.policy.base_fee_msat}</p>
+								<p>Fee rate (ppm): {selectedChannel.policy.fee_rate_ppm}</p>
+								<p>Max HTLC (msat): {selectedChannel.policy.max_htlc_msat}</p>
+								<p>Min HTLC (msat): {selectedChannel.policy.min_htlc_msat}</p>
+								<p>Timelock delta: {selectedChannel.policy.timelock_delta}</p>
+								<div className="lnpub-inline-actions">
+									<button
+										type="button"
+										className="btn-lp-sm btn-lp-a"
+										onClick={() => {
+											setOpenModal("updatePolocy");
+										}}
+									>
+										Edit policy
+									</button>
+									<button
+										type="button"
+										className="btn-lp-sm btn-lp-b"
+										onClick={() => {
+											setOpenModal("closeChannel");
+										}}
+									>
+										Close channel
+									</button>
+								</div>
+							</div>
+						)}
+						{!selectedChannel.policy && <div>No policy found for this channel.</div>}
+					</>
+				}
+			/>
+		);
 	}
-	if (openModal === 'updatePolocy') {
-		return <PromptForActionModal title="Update Policy"
-			actionText="Update Policy"
-			actionType={ActionType.NORMAL}
-			closeModal={() => { setOpenModal('showPolicy') }}
-			action={() => { updatePolicy(); setOpenModal('showPolicy') }}
-			jsx={<>
-				{selectedChannel.policy && <div>
-					<div>
-						<label>Base Fee Msat:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="baseFeeMsat" value={baseFeeMsat} onChange={e => { setBaseFeeMsat(+e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Fee Rate Ppm:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="feeRatePpm" value={feeRatePpm} onChange={e => { setFeeRatePpm(+e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Max HTLC Msat:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="maxHtlcMsat" value={maxHtlcMsat} onChange={e => { setMaxHtlcMsat(+e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Min HTLC Msat:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="minHtlcMsat" value={minHtlcMsat} onChange={e => { setMinHtlcMsat(+e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Time Lock Delta:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="timeLockDelta" value={timeLockDelta} onChange={e => { setTimeLockDelta(+e.target.value) }}></input>
-					</div>
-				</div>}
-			</>}
-		/>
+	if (openModal === "updatePolocy") {
+		return (
+			<PromptForActionModal
+				title="Update Policy"
+				actionText="Update Policy"
+				actionType={ActionType.NORMAL}
+				variant="lnpub"
+				closeModal={() => {
+					setOpenModal("showPolicy");
+				}}
+				action={() => {
+					void updatePolicy();
+					setOpenModal("showPolicy");
+				}}
+				jsx={
+					selectedChannel.policy ? (
+						<div className="lnpub-form-stack">
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-base-fee">Base fee (msat)</label>
+								<input
+									id="lnpub-base-fee"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="base fee msat"
+									value={baseFeeMsat ?? ""}
+									onChange={(e) => {
+										setBaseFeeMsat(+e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-fee-rate">Fee rate (ppm)</label>
+								<input
+									id="lnpub-fee-rate"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="fee rate ppm"
+									value={feeRatePpm || ""}
+									onChange={(e) => {
+										setFeeRatePpm(+e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-max-htlc">Max HTLC (msat)</label>
+								<input
+									id="lnpub-max-htlc"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="max HTLC msat"
+									value={maxHtlcMsat || ""}
+									onChange={(e) => {
+										setMaxHtlcMsat(+e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-min-htlc">Min HTLC (msat)</label>
+								<input
+									id="lnpub-min-htlc"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="min HTLC msat"
+									value={minHtlcMsat || ""}
+									onChange={(e) => {
+										setMinHtlcMsat(+e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-timelock">Timelock delta</label>
+								<input
+									id="lnpub-timelock"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="timelock delta"
+									value={timeLockDelta || ""}
+									onChange={(e) => {
+										setTimeLockDelta(+e.target.value);
+									}}
+								/>
+							</div>
+						</div>
+					) : null
+				}
+			/>
+		);
 	}
-	if (openModal === 'closeChannel') {
-		return <PromptForActionModal title="Close Channel"
-			actionText={force ? "Force Close Channel" : "Close Channel"}
-			actionType={ActionType.NORMAL}
-			closeModal={() => { setOpenModal('showPolicy') }}
-			action={() => { closeChannel(); setOpenModal('showPolicy') }}
-			jsx={<>
-				<p>Are you sure you want to close the channel?</p>
-				{!force && <div>
-					<label >Sats per VByte:</label>
-					<input type="text" style={{ backgroundColor: 'black' }} placeholder="satPerVByte" value={satsPerVByte} onChange={e => { setSatsPerVByte(+e.target.value) }}></input>
-				</div>}
-				<div>
-					<label >Force:</label>
-					<Checkbox state={force} setState={(e) => { setForce(e.target.checked) }} id="forceClose" />
-				</div>
-			</>}
-		/>
+	if (openModal === "closeChannel") {
+		return (
+			<PromptForActionModal
+				title="Close Channel"
+				actionText={force ? "Force Close Channel" : "Close Channel"}
+				actionType={ActionType.NORMAL}
+				variant="lnpub"
+				closeModal={() => {
+					setOpenModal("showPolicy");
+				}}
+				action={() => {
+					void closeChannel();
+					setOpenModal("showPolicy");
+				}}
+				jsx={
+					<div className="lnpub-form-stack">
+						<p>Are you sure you want to close this channel?</p>
+						{!force && (
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-close-sats-vb">Sats per vbyte</label>
+								<input
+									id="lnpub-close-sats-vb"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="sats per vbyte"
+									value={satsPerVByte || ""}
+									onChange={(e) => {
+										setSatsPerVByte(+e.target.value);
+									}}
+								/>
+							</div>
+						)}
+						<div className="lnpub-form-row">
+							<label htmlFor="forceClose">Force close</label>
+							<Checkbox
+								state={force}
+								setState={(e) => {
+									setForce(e.target.checked);
+								}}
+								id="forceClose"
+							/>
+						</div>
+					</div>
+				}
+			/>
+		);
 	}
 
 	return null

--- a/src/Pages/Channels/OpenChannel.tsx
+++ b/src/Pages/Channels/OpenChannel.tsx
@@ -5,93 +5,171 @@ import { toast } from "react-toastify";
 import { NprofileView } from "@/State/scoped/backups/sources/selectors";
 
 export const OpenChannel = ({ adminSource }: { adminSource: NprofileView }) => {
-	const [openModal, setOpenModal] = useState<'addPeer' | 'openChannel' | ''>('');
-	const [peerUri, setPeerUri] = useState<string>('');
-	const [peerPubkey, setPeerPubkey] = useState<string>('');
+	const [openModal, setOpenModal] = useState<"addPeer" | "openChannel" | "">("");
+	const [peerUri, setPeerUri] = useState<string>("");
+	const [peerPubkey, setPeerPubkey] = useState<string>("");
 	const [channelAmount, setChannelAmount] = useState<number>(0);
 	const [satsPerVByte, setSatsPerVByte] = useState<number>(0);
 	const addPeer = async () => {
 		if (!peerUri) {
-			toast.error('Please enter a valid peer uri')
-			return
+			toast.error("Please enter a valid peer uri");
+			return;
 		}
-		const [pubkey, addr] = peerUri.split('@')
+		const [pubkey, addr] = peerUri.split("@");
 		if (!pubkey || !addr) {
-			toast.error('Please enter a valid peer uri')
-			return
+			toast.error("Please enter a valid peer uri");
+			return;
 		}
-		const [host, port] = addr.split(':')
+		const [host, port] = addr.split(":");
 		if (!host || !port || isNaN(+port)) {
-			toast.error('Please enter a valid peer uri')
-			return
+			toast.error("Please enter a valid peer uri");
+			return;
 		}
-		const client = await getNostrClient({ pubkey: adminSource.lpk, relays: adminSource.relays }, adminSource.keys)
-		const res = await client.AddPeer({ pubkey, host, port: +port })
-		if (res.status === 'ERROR') {
-			toast.error(res.reason)
-			return
+		const client = await getNostrClient(
+			{ pubkey: adminSource.lpk, relays: adminSource.relays },
+			adminSource.keys
+		);
+		const res = await client.AddPeer({ pubkey, host, port: +port });
+		if (res.status === "ERROR") {
+			toast.error(res.reason);
+			return;
 		}
-		toast.success('Peer added successfully')
-	}
+		toast.success("Peer added successfully");
+	};
 
 	const openChannel = async () => {
 		if (!peerPubkey) {
-			toast.error('Please enter a valid peer pubkey')
-			return
+			toast.error("Please enter a valid peer pubkey");
+			return;
 		}
 		if (channelAmount <= 0) {
-			toast.error('Please enter a valid channel amount')
-			return
+			toast.error("Please enter a valid channel amount");
+			return;
 		}
 		if (satsPerVByte <= 0) {
-			toast.error('Please enter a valid sats per vbyte')
-			return
+			toast.error("Please enter a valid sats per vbyte");
+			return;
 		}
-		const client = await getNostrClient({ pubkey: adminSource.lpk, relays: adminSource.relays }, adminSource.keys)
-		const res = await client.OpenChannel({ node_pubkey: peerPubkey, local_funding_amount: channelAmount, sat_per_v_byte: satsPerVByte })
-		if (res.status === 'ERROR') {
-			toast.error(res.reason)
-			return
+		const client = await getNostrClient(
+			{ pubkey: adminSource.lpk, relays: adminSource.relays },
+			adminSource.keys
+		);
+		const res = await client.OpenChannel({
+			node_pubkey: peerPubkey,
+			local_funding_amount: channelAmount,
+			sat_per_v_byte: satsPerVByte,
+		});
+		if (res.status === "ERROR") {
+			toast.error(res.reason);
+			return;
 		}
-		toast.success('Channel opened successfully')
-	}
+		toast.success("Channel opened successfully");
+	};
 
 	return (
 		<div>
-			<div>
-				<button onClick={() => setOpenModal('addPeer')}>ADD PEER</button>
-				<button onClick={() => setOpenModal('openChannel')}>ADD CHANNEL</button>
-
+			<div className="Channels_open-actions">
+				<button type="button" className="btn-lp" onClick={() => setOpenModal("addPeer")}>
+					Add peer
+				</button>
+				<button type="button" className="btn-lp-out" onClick={() => setOpenModal("openChannel")}>
+					Add channel
+				</button>
 			</div>
-			{openModal === 'addPeer' && <PromptForActionModal title="Add Peer"
-				actionText="Add Peer"
-				actionType={ActionType.NORMAL}
-				closeModal={() => { setOpenModal('') }}
-				action={() => { addPeer(); setOpenModal('') }}
-				jsx={<>
-					<label>Peer Uri:</label>
-					<input type="text" style={{ backgroundColor: 'black' }} placeholder="pubkey@address:port" value={peerUri} onChange={e => { setPeerUri(e.target.value) }}></input></>}
-			/>}
-			{openModal === 'openChannel' && <PromptForActionModal title="Open Channel"
-				actionText="Open Channel"
-				actionType={ActionType.NORMAL}
-				closeModal={() => { setOpenModal('') }}
-				action={() => { openChannel(); setOpenModal('') }}
-				jsx={<>
-					<div>
-						<label>Peer Pubkey:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="pubkey" value={peerPubkey} onChange={e => { setPeerPubkey(e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Channel Amount:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="amount" value={channelAmount} onChange={e => { setChannelAmount(+e.target.value) }}></input>
-					</div>
-					<div>
-						<label>Sats Per VByte:</label>
-						<input type="text" style={{ backgroundColor: 'black' }} placeholder="satsPerVByte" value={satsPerVByte} onChange={e => { setSatsPerVByte(+e.target.value) }}></input>
-					</div>
-				</>}
-			/>}
+			{openModal === "addPeer" && (
+				<PromptForActionModal
+					title="Add Peer"
+					actionText="Add Peer"
+					actionType={ActionType.NORMAL}
+					variant="lnpub"
+					closeModal={() => {
+						setOpenModal("");
+					}}
+					action={() => {
+						void addPeer();
+						setOpenModal("");
+					}}
+					jsx={
+						<div className="lnpub-form-stack">
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-peer-uri">Peer URI</label>
+								<input
+									id="lnpub-peer-uri"
+									className="lnpub-input"
+									type="text"
+									autoComplete="off"
+									placeholder="pubkey@address:port"
+									value={peerUri}
+									onChange={(e) => {
+										setPeerUri(e.target.value);
+									}}
+								/>
+							</div>
+						</div>
+					}
+				/>
+			)}
+			{openModal === "openChannel" && (
+				<PromptForActionModal
+					title="Open Channel"
+					actionText="Open Channel"
+					actionType={ActionType.NORMAL}
+					variant="lnpub"
+					closeModal={() => {
+						setOpenModal("");
+					}}
+					action={() => {
+						void openChannel();
+						setOpenModal("");
+					}}
+					jsx={
+						<div className="lnpub-form-stack">
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-peer-pubkey">Peer pubkey</label>
+								<input
+									id="lnpub-peer-pubkey"
+									className="lnpub-input"
+									type="text"
+									autoComplete="off"
+									placeholder="pubkey"
+									value={peerPubkey}
+									onChange={(e) => {
+										setPeerPubkey(e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-channel-amount">Channel amount (sats)</label>
+								<input
+									id="lnpub-channel-amount"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="amount"
+									value={channelAmount || ""}
+									onChange={(e) => {
+										setChannelAmount(+e.target.value);
+									}}
+								/>
+							</div>
+							<div className="lnpub-form-row">
+								<label htmlFor="lnpub-sats-vb">Sats per vbyte</label>
+								<input
+									id="lnpub-sats-vb"
+									className="lnpub-input"
+									type="text"
+									inputMode="numeric"
+									placeholder="sats per vbyte"
+									value={satsPerVByte || ""}
+									onChange={(e) => {
+										setSatsPerVByte(+e.target.value);
+									}}
+								/>
+							</div>
+						</div>
+					}
+				/>
+			)}
 		</div>
 	);
 };

--- a/src/Pages/Channels/index.tsx
+++ b/src/Pages/Channels/index.tsx
@@ -90,10 +90,11 @@ const Channels = () => {
 				if (c.remote_balance > max) {
 					max = c.remote_balance
 				}
+				const avatar = channelRoboAvatarUrl(c)
 				if (c.active) {
-					active.push({ avatar: "", id: i, name: c.label, localSatAmount: c.local_balance, RemoteSatAmount: c.remote_balance, channel: c })
+					active.push({ avatar, id: i, name: c.label, localSatAmount: c.local_balance, RemoteSatAmount: c.remote_balance, channel: c })
 				} else {
-					offline.push({ avatar: "", id: i, name: c.label, encumbered: c.local_balance, timeStamp: c.inactive_since_unix, subNode: "Initiate force-close", channel: c })
+					offline.push({ avatar, id: i, name: c.label, encumbered: c.local_balance, timeStamp: c.inactive_since_unix, subNode: "Initiate force-close", channel: c })
 				}
 			})
 			setMaxBalance(max);
@@ -134,10 +135,10 @@ const Channels = () => {
 			</IonHeader>
 			<IonContent className="ion-padding ion-content-no-footer">
 				{error && (
-					<div style={{ color: "red", padding: 12 }}>
-						<div style={{ fontWeight: 700, marginBottom: 8 }}>Something went wrong</div>
-						<div style={{ opacity: 0.85, marginBottom: 12 }}>{error}</div>
-						<div style={{ display: "flex", gap: 8 }}>
+					<div className="callout--lp Channels_error-callout">
+						<div className="Channels_error-title">Something went wrong</div>
+						<div className="Channels_error-body">{error}</div>
+						<div className="Channels_error-actions">
 							<IonButton onClick={() => void fetchChannels()}>Retry</IonButton>
 							<IonButton fill="outline" onClick={() => router.push("/metrics/select", "back")}>
 								Change Source
@@ -167,10 +168,10 @@ const Channels = () => {
 											<div className="avatar">
 												<img
 													src={channel.avatar}
-													width={12}
-													height={12}
-													className=""
-													alt="avatar"
+													width={32}
+													height={32}
+													decoding="async"
+													alt=""
 												/>
 												<div>{channel.name}</div>
 											</div>
@@ -222,10 +223,10 @@ const Channels = () => {
 											<div className="avatar">
 												<img
 													src={channel.avatar}
-													width={12}
-													height={12}
-													className=""
-													alt="avatar"
+													width={32}
+													height={32}
+													decoding="async"
+													alt=""
 												/>
 												<div>{channel.name}</div>
 											</div>
@@ -289,7 +290,7 @@ const SatAmountBar: React.FC<ComponentProps> = ({
 	return (
 		<div
 			style={{
-				backgroundColor: `${type === "local" ? "#ff7700" : "#5912c7"}`,
+				backgroundColor: type === "local" ? "var(--lp-a, #ff8a00)" : "var(--lp-b, #f040f5)",
 				width: `calc(${percent} * 100%)`,
 				textWrap: "nowrap",
 			}}
@@ -298,6 +299,15 @@ const SatAmountBar: React.FC<ComponentProps> = ({
 		</div>
 	);
 };
+
+function channelRoboAvatarUrl(channel: OpenChannel): string {
+	const seed =
+		channel.channel_id?.trim() ||
+		channel.channel_point?.trim() ||
+		channel.label?.trim() ||
+		"channel"
+	return `https://robohash.org/${encodeURIComponent(seed)}.png?bgset=bg1`
+}
 
 const formatCryptoAmount = (amount: number): string => {
 	if (amount >= 1000000) {

--- a/src/Pages/Metrics/index.tsx
+++ b/src/Pages/Metrics/index.tsx
@@ -46,17 +46,19 @@ const Metrics = ({ match, location, history }: RouteComponentProps) => {
 
 	return (
 		<IonPage>
-			<IonRouterOutlet key={`metrics-subtree:${selectedId ?? "none"}`}>
-				<Route exact path={`${match.url}/select`} component={MetricsSelectSource} />
+			<div data-product="lnpub" data-theme="dark" style={{ display: "contents" }}>
+				<IonRouterOutlet key={`metrics-subtree:${selectedId ?? "none"}`}>
+					<Route exact path={`${match.url}/select`} component={MetricsSelectSource} />
 
-				<GuardedRoute exact path={match.url} component={Dashboard} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/earnings`} component={Earnings} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/routing`} component={Routing} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/manage`} component={Manage} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/channels`} component={Channels} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/swaps`} component={AdminSwaps} guards={[requireSelectedAdminSourceGuard]} />
-				<GuardedRoute path={`${match.url}/assets-liabilities`} component={AssetsAndLiab} guards={[requireSelectedAdminSourceGuard]} />
-			</IonRouterOutlet>
+					<GuardedRoute exact path={match.url} component={Dashboard} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/earnings`} component={Earnings} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/routing`} component={Routing} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/manage`} component={Manage} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/channels`} component={Channels} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/swaps`} component={AdminSwaps} guards={[requireSelectedAdminSourceGuard]} />
+					<GuardedRoute path={`${match.url}/assets-liabilities`} component={AssetsAndLiab} guards={[requireSelectedAdminSourceGuard]} />
+				</IonRouterOutlet>
+			</div>
 		</IonPage>
 	);
 };

--- a/src/globalTypes.ts
+++ b/src/globalTypes.ts
@@ -76,12 +76,8 @@ export interface ModalProps {
   hide: () => void;
   modalContent: JSX.Element;
   headerText?: string;
-}
-
-export interface ModalProps {
-  isShown: boolean;
-  hide: () => void;
-  modalContent: JSX.Element;
+  /** When set, modal frame uses Lightning.pub dashboard styling (portaled modals). */
+  variant?: "default" | "lnpub";
 }
 
 export interface SwItemData {

--- a/src/styles/shocknet-lnpub.scss
+++ b/src/styles/shocknet-lnpub.scss
@@ -1,0 +1,187 @@
+/*
+ * SHOCKNET — Lightning.pub product styles (dashboard scope)
+ * Based on shocknet-lnpub.css v1.2 — scoped to [data-product="lnpub"] only.
+ */
+
+[data-product="lnpub"] {
+	--lp-a: #ff8a00;
+	--lp-b: #f040f5;
+	--prod-a: var(--lp-a);
+	--prod-b: var(--lp-b);
+	--prod-on-a: #111213;
+	--prod-on-b: #f1f1f1;
+	--prod-gradient: linear-gradient(90deg, var(--lp-a), var(--lp-b));
+}
+
+@media (prefers-color-scheme: light) {
+	[data-product="lnpub"] {
+		--lp-a: #ff9900;
+		--lp-b: #d75ad7;
+	}
+}
+
+[data-product="lnpub"] {
+	input:focus,
+	textarea:focus,
+	select:focus {
+		border-color: var(--lp-a);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--lp-a) 20%, transparent);
+		outline: none;
+	}
+}
+
+[data-product="lnpub"] .btn-lp,
+[data-product="lnpub"] .btn-lp-sm {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 100%;
+	border: none;
+	border-radius: 10px;
+	padding: 12px 18px;
+	font-family: Montserrat, system-ui, sans-serif;
+	font-size: 15px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	text-transform: none;
+	cursor: pointer;
+	transition: box-shadow 0.2s ease, filter 0.15s ease;
+	background: linear-gradient(90deg, var(--lp-a), var(--lp-b));
+	color: #ffffff;
+}
+
+[data-product="lnpub"] .btn-lp-sm {
+	padding: 8px 14px;
+	font-size: 13px;
+	border-radius: 8px;
+	width: auto;
+	min-width: 0;
+}
+
+[data-product="lnpub"] .btn-lp:hover,
+[data-product="lnpub"] .btn-lp-sm:hover {
+	box-shadow: 0 0 20px rgba(255, 138, 0, 0.22);
+}
+
+[data-product="lnpub"] .btn-lp:active,
+[data-product="lnpub"] .btn-lp-sm:active {
+	filter: brightness(1.05);
+}
+
+[data-product="lnpub"] .btn-lp-a {
+	background: var(--lp-a);
+	border: 1px solid var(--lp-a);
+	color: #111213;
+}
+
+[data-product="lnpub"] .btn-lp-b {
+	background: var(--lp-b);
+	border: 1px solid var(--lp-b);
+	color: #f1f1f1;
+}
+
+[data-product="lnpub"] .btn-lp-out {
+	background: transparent;
+	border: 1px solid var(--lp-a);
+	color: var(--lp-a);
+}
+
+[data-product="lnpub"] .btn-lp-out:hover {
+	box-shadow: 0 0 20px rgba(255, 138, 0, 0.22);
+}
+
+[data-product="lnpub"] .btn-lp-in {
+	background: transparent;
+	border: 1px solid var(--lp-b);
+	color: var(--lp-b);
+}
+
+[data-product="lnpub"] .btn-lp-in:hover {
+	box-shadow: 0 0 20px rgba(240, 64, 245, 0.22);
+}
+
+[data-product="lnpub"] .pill-lp {
+	background: color-mix(in srgb, var(--lp-a) 14%, transparent);
+	border: 1px solid var(--lp-a);
+	color: var(--lp-a);
+}
+
+[data-product="lnpub"] .pill-lp2 {
+	background: color-mix(in srgb, var(--lp-b) 14%, transparent);
+	border: 1px solid var(--lp-b);
+	color: var(--lp-b);
+}
+
+@media (prefers-color-scheme: light) {
+	[data-product="lnpub"] .pill-lp {
+		color: #cc7700;
+		border-color: #ff9900;
+		background: color-mix(in srgb, #ff9900 14%, transparent);
+	}
+
+	[data-product="lnpub"] .pill-lp2 {
+		color: #a83fa8;
+		border-color: #d75ad7;
+		background: color-mix(in srgb, #d75ad7 14%, transparent);
+	}
+}
+
+[data-product="lnpub"] .callout--lp {
+	background: color-mix(in srgb, var(--lp-a) 7%, transparent);
+	border-color: color-mix(in srgb, var(--lp-a) 20%, transparent);
+}
+
+[data-product="lnpub"] .icon-cell--lp:hover {
+	background: color-mix(in srgb, var(--lp-a) 10%, transparent);
+}
+
+[data-product="lnpub"] .product-bar--lp {
+	background: linear-gradient(180deg, var(--lp-a), var(--lp-b));
+}
+
+/* Form rows inside LNPUB modals (channels / metrics) */
+[data-product="lnpub"] .lnpub-form-stack {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	text-align: left;
+	margin-top: 8px;
+}
+
+[data-product="lnpub"] .lnpub-form-row {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+[data-product="lnpub"] .lnpub-form-row label {
+	font-size: 12px;
+	font-weight: 600;
+	color: color-mix(in srgb, var(--ion-text-color, #fff) 72%, transparent);
+}
+
+[data-product="lnpub"] .lnpub-input {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 10px 12px;
+	border-radius: 8px;
+	border: 1px solid color-mix(in srgb, var(--lp-a) 35%, transparent);
+	background: color-mix(in srgb, var(--ion-background-color, #16191c) 92%, #000);
+	color: var(--ion-text-color, #fcfcfc);
+	font-size: 14px;
+	font-family: Montserrat, system-ui, sans-serif;
+}
+
+[data-product="lnpub"] .lnpub-inline-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: center;
+	margin-top: 12px;
+}
+
+[data-product="lnpub"] .lnpub-inline-actions .btn-lp-sm {
+	flex: 1 1 auto;
+	min-width: 120px;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the designer’s Lightning.pub product CSS as a **scoped** stylesheet so the rest of the wallet is unchanged.

- Adds `src/styles/shocknet-lnpub.scss` (tokens `--lp-a` / `--lp-b`, semantic `--prod-*`, `btn-lp` / `btn-lp-sm` / `btn-lp-a|b|out|in`, pills, callout, form focus utilities, and `.lnpub-form-*` helpers for modal forms). Imported once from `App.scss`.
- Wraps only the metrics subtree (`IonRouterOutlet` in `Metrics/index.tsx`) with `data-product="lnpub"` and `data-theme="dark"` using `display: contents` so routing behavior is unchanged.
- **Modals:** `Modal` accepts optional `variant="lnpub"`. The portaled `StyledModal` sets `data-product="lnpub"` and uses a gradient border frame so designer classes work **outside** the metrics DOM (portals). Default modals keep the existing blue border / light background.
- **PromptForActionModal:** Optional `variant="lnpub"` drives LNPUB header underline, stacked primary/outline-style actions, and passes `variant` through to `Modal`. Fixes broken `@import` paths to `_modals.module` / `_buttons.module`. Removes duplicate `ModalProps` in `globalTypes.ts`.
- **Channels:** Uses LNPUB buttons for add peer / add channel; channel policy / update / close modals use `variant="lnpub"` with structured form markup and `.lnpub-input` styling. Re-applies stable robohash avatars, bar colors from `--lp-a`/`--lp-b`, and a `callout--lp` error block.

## Testing

- `npm run build:web` succeeds.
- `npx eslint` on touched files (project-wide lint has unrelated failures).

## Notes

- Light theme tokens from the designer sheet are approximated with `@media (prefers-color-scheme: light)` on `[data-product="lnpub"]` only; the metrics wrapper is currently `data-theme="dark"` for consistency with the dark app shell.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4424f5fb-336d-490d-8392-840f31f5d50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4424f5fb-336d-490d-8392-840f31f5d50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

