### PR TITLE
feat(#590): admin is unable to rename node

### DIFF
--- a/src/Pages/Manage/index.tsx
+++ b/src/Pages/Manage/index.tsx
@@ -14,26 +14,15 @@ import MetricsSubPageToolbar from "@/Layout2/Metrics/MetricsSubPageToolbar";
 import { nip19 } from "nostr-tools";
 
 
-import { useAppSelector } from "@/State/store/hooks";
+import { publishNodeBeacon } from "@/helpers/remoteBackups";
+import { sourcesActions } from "@/State/scoped/backups/sources/slice";
+import { useAppDispatch, useAppSelector } from "@/State/store/hooks";
 import { selectAdminNprofileViews } from "@/State/scoped/backups/sources/selectors";
 import { selectSelectedMetricsAdminSourceId } from "@/State/runtime/slice";
 
 const Manage = () => {
 	const router = useIonRouter();
-
-	const [isShowQuestion, setIsShowQuestion] = useState<boolean>(false);
-	const [isRevealed, setIsRevealed] = useState<boolean>(false);
-	const [seed, setSeed] = useState<string[]>([])
-	const [nodeName, setNodeName] = useState<string>("");
-	const [specificNostr, setSpecificNostr] = useState<string>("");
-	const [isNodeDiscover, setIsNodeDiscover] = useState<boolean>(true);
-	const [isDefaultManage, setIsDefaultManage] = useState<boolean>(true);
-	const [isAutoService, setIsAutoService] = useState<boolean>(true);
-	const [isRecoveryKey, setIsRecoveryKey] = useState<boolean>(true);
-
-	const [error, setError] = useState<string | null>(null);
-	const [presentLoading, dismissLoading] = useIonLoading();
-
+	const dispatch = useAppDispatch();
 
 	const admins = useAppSelector(selectAdminNprofileViews);
 	const selectedId = useAppSelector(selectSelectedMetricsAdminSourceId);
@@ -41,6 +30,20 @@ const Manage = () => {
 		() => admins.find(a => a.sourceId === selectedId),
 		[admins, selectedId]
 	)!;
+
+	const [isShowQuestion, setIsShowQuestion] = useState<boolean>(false);
+	const [isRevealed, setIsRevealed] = useState<boolean>(false);
+	const [seed, setSeed] = useState<string[]>([])
+	const [nodeName, setNodeName] = useState<string>(() => adminSource.beaconName || adminSource.label || "");
+	const [specificNostr, setSpecificNostr] = useState<string>("");
+	const [isNodeDiscover, setIsNodeDiscover] = useState<boolean>(true);
+	const [isDefaultManage, setIsDefaultManage] = useState<boolean>(true);
+	const [isAutoService, setIsAutoService] = useState<boolean>(true);
+	const [isRecoveryKey, setIsRecoveryKey] = useState<boolean>(true);
+	const [isSaving, setIsSaving] = useState<boolean>(false);
+
+	const [error, setError] = useState<string | null>(null);
+	const [presentLoading, dismissLoading] = useIonLoading();
 
 	const seeditems: string[] = [
 		"albert",
@@ -134,8 +137,54 @@ const Manage = () => {
 		</React.Fragment>
 	);
 
-	const onDone = () => {
-		router.push("/metrics", "back")
+	const onDone = async () => {
+		setError(null);
+
+		const trimmedNodeName = nodeName.trim();
+		const publishedNodeName = adminSource.beaconName?.trim() ?? "";
+
+		if (trimmedNodeName === publishedNodeName) {
+			router.push("/metrics", "back");
+			return;
+		}
+
+		if (!trimmedNodeName) {
+			const msg = "Node name cannot be empty";
+			setError(msg);
+			toast.error(<Toast title="Manage Error" message={msg} />);
+			return;
+		}
+
+		setIsSaving(true);
+		await dismissLoading();
+		await presentLoading({ message: "Saving node settings..." });
+
+		try {
+			const createdAtUnix = await publishNodeBeacon({
+				pubkey: adminSource.lpk,
+				relays: adminSource.relays,
+				keys: adminSource.keys,
+				name: trimmedNodeName,
+			});
+
+			dispatch(
+				sourcesActions.recordBeaconForSource({
+					sourceId: adminSource.sourceId,
+					name: trimmedNodeName,
+					seenAtMs: createdAtUnix * 1000,
+				})
+			);
+			setNodeName(trimmedNodeName);
+			router.push("/metrics", "back");
+		} catch (e) {
+			console.error(e);
+			const msg = e instanceof Error ? e.message : "Failed to save node settings";
+			setError(msg);
+			toast.error(<Toast title="Manage Error" message={msg} />);
+		} finally {
+			setIsSaving(false);
+			await dismissLoading();
+		}
 	}
 	return (
 		<IonPage className="ion-page-width">
@@ -159,9 +208,8 @@ const Manage = () => {
 							<div className="line" />
 						</div>
 						<div className="input-group">
-							<div className="bg-over"></div>
 							<span>Node name, seen by wallet users (Nostr):</span>
-							<input type="text" placeholder="Nodey McNodeFace" value={nodeName} onChange={(e) => { setNodeName(e.target.value) }} />
+							<input type="text" placeholder="Nodey McNodeFace" value={nodeName} disabled={isSaving} onChange={(e) => { setNodeName(e.target.value) }} />
 						</div>
 						<div className="checkbox">
 							<div className="bg-over"></div>
@@ -267,7 +315,7 @@ const Manage = () => {
 							{isRevealed ? "Click to hide seed" : "Click to reveal seed"}
 						</div>
 					</div>
-					<button onClick={onDone} className="Manage_save">
+					<button onClick={() => void onDone()} className="Manage_save" disabled={isSaving}>
 						Done
 					</button>
 					<div className="Manage_footer">

--- a/src/helpers/remoteBackups.spec.ts
+++ b/src/helpers/remoteBackups.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPublicKey } from "nostr-tools";
+import { hexToBytes } from "@noble/hashes/utils";
+import { publishNodeBeacon } from "./remoteBackups";
+import { newNip78Event, publishNostrEvent, pubServiceTag } from "../Api/nostrHandler";
+
+vi.mock("nostr-tools", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("nostr-tools")>();
+    return {
+        ...actual,
+        finalizeEvent: vi.fn((event) => ({
+            ...event,
+            id: "signed-id",
+            sig: "signed-sig",
+        })),
+    };
+});
+
+vi.mock("../Api/nostrHandler", () => ({
+    getNip78Event: vi.fn(),
+    pubServiceTag: "Lightning.Pub",
+    newNip78Event: vi.fn((data: string, pubkey: string, dTag: string) => ({
+        content: data,
+        created_at: 321,
+        kind: 30078,
+        tags: [["d", dTag]],
+        pubkey,
+    })),
+    publishNostrEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const newNip78EventMock = vi.mocked(newNip78Event);
+const publishNostrEventMock = vi.mocked(publishNostrEvent);
+
+describe("publishNodeBeacon", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("publishes a signed beacon event with the trimmed node name", async () => {
+        const privateKey = "1".padStart(64, "0");
+        const publicKey = getPublicKey(hexToBytes(privateKey));
+
+        const createdAtUnix = await publishNodeBeacon({
+            pubkey: publicKey,
+            relays: ["wss://relay.example"],
+            keys: { privateKey, publicKey },
+            name: "  Nodey McNodeFace  ",
+        });
+
+        expect(createdAtUnix).toBe(321);
+        expect(newNip78EventMock).toHaveBeenCalledWith(
+            JSON.stringify({ type: "service", name: "Nodey McNodeFace" }),
+            publicKey,
+            pubServiceTag
+        );
+        expect(publishNostrEventMock).toHaveBeenCalledTimes(1);
+        expect(publishNostrEventMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: JSON.stringify({ type: "service", name: "Nodey McNodeFace" }),
+                created_at: 321,
+                kind: 30078,
+                pubkey: publicKey,
+                tags: [["d", pubServiceTag]],
+                sig: expect.any(String),
+            }),
+            ["wss://relay.example"]
+        );
+    });
+
+    it("rejects an empty node name before trying to publish", async () => {
+        const privateKey = "1".padStart(64, "0");
+        const publicKey = getPublicKey(hexToBytes(privateKey));
+
+        await expect(
+            publishNodeBeacon({
+                pubkey: publicKey,
+                relays: ["wss://relay.example"],
+                keys: { privateKey, publicKey },
+                name: "   ",
+            })
+        ).rejects.toThrow("Node name cannot be empty");
+
+        expect(newNip78EventMock).not.toHaveBeenCalled();
+        expect(publishNostrEventMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/helpers/remoteBackups.ts
+++ b/src/helpers/remoteBackups.ts
@@ -1,6 +1,9 @@
+import { hexToBytes } from "@noble/hashes/utils";
+import { finalizeEvent } from "nostr-tools";
 import logger from "../Api/helpers/logger"
 import { getNip78Event, newNip78Event, publishNostrEvent, pubServiceTag } from "../Api/nostrHandler"
 import { getDeviceId } from "../constants"
+import { NostrKeyPair } from "../lib/regex";
 import { getSanctumNostrExtention } from "./nip07Extention"
 
 export const fetchRemoteBackup = async (dTag?: string): Promise<{ result: 'accessTokenMissing' } | { result: 'success', decrypted: string }> => {
@@ -147,4 +150,35 @@ export const fetchBeaconDiscovery = async (pubkey: string, relays: string[]): Pr
         name: data.name
     }
 
+}
+
+export const publishNodeBeacon = async ({
+    pubkey,
+    relays,
+    keys,
+    name,
+}: {
+    pubkey: string;
+    relays: string[];
+    keys: NostrKeyPair;
+    name: string;
+}): Promise<number> => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+        throw new Error("Node name cannot be empty");
+    }
+    if (relays.length === 0) {
+        throw new Error("Cannot publish node name without any relays");
+    }
+
+    const beaconEvent = newNip78Event(
+        JSON.stringify({ type: "service", name: trimmedName }),
+        pubkey,
+        pubServiceTag
+    );
+    const signed = finalizeEvent(beaconEvent, hexToBytes(keys.privateKey));
+
+    await publishNostrEvent(signed, relays);
+    return signed.created_at;
 }


### PR DESCRIPTION
## Summary

Fixes [#590](https://github.com/shocknet/wallet2/issues/590): admins can now rename their node from the Manage screen.

### What changed

- Added `publishNodeBeacon()` in `src/helpers/remoteBackups.ts` to publish a NIP-78 service beacon update with the new node name.
- Updated `src/Pages/Manage/index.tsx`:
  - Node name input is now editable on Manage.
  - `Done` now persists name changes to Nostr (instead of only navigating back).
  - Added validation for empty names.
  - Added saving state (`isSaving`) to prevent duplicate submits.
  - Added error handling and user feedback for publish failures.
  - On success, updates local source beacon metadata via `recordBeaconForSource`.
- Added unit tests for publish flow in `src/helpers/remoteBackups.spec.ts`.

## Notes

This PR only includes changes required to fix node rename behavior from Manage.  
No routing/test-environment workarounds are included.