### PR TITLE
Fix noffer clipboard confirm by deferring parse to Send page.

### DIFF
--- a/src/lib/backgroundHooks/useWatchClipboard.spec.tsx
+++ b/src/lib/backgroundHooks/useWatchClipboard.spec.tsx
@@ -273,6 +273,41 @@ describe("useWatchClipboard happy path", () => {
 		// but we did NOT navigate
 		expect(mockPush).not.toHaveBeenCalled();
 	});
+
+	it("skips noffer parse and navigates to send — Send parses with selected source keys", async () => {
+		const noffer = "noffer1qqsrf5h4ya83jk8u6t9jgc76h6kalz3plp9vusjpm2ygqgalqhxgp9gpr9mhxue69uhhyetvv9ujumrfva58gmnfdenjuur4vgpp2ctywejkuar4wfhh2um5dae8gmmfwdjnqdsrqypqqudzmz";
+
+		mockClipboardRead.mockResolvedValue({
+			type: "text/plain",
+			value: noffer,
+		});
+
+		mockIdentifyBitcoinInput.mockReturnValue({
+			classification: InputClassification.NOFFER,
+			value: noffer,
+		});
+
+		const alertResult = Promise.resolve({ role: "confirm" });
+		mockShowAlert.mockReturnValue(alertResult);
+
+		renderHarness();
+
+		await act(async () => {
+			vi.advanceTimersByTime(60);
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			await alertResult;
+			await Promise.resolve();
+		});
+
+		expect(mockParseBitcoinInput).not.toHaveBeenCalled();
+		expect(mockPush).toHaveBeenCalledWith({
+			pathname: "/send",
+			state: { input: noffer },
+		});
+	});
 });
 
 describe("useWatchClipboard guards", () => {

--- a/src/lib/backgroundHooks/useWatchClipboard.ts
+++ b/src/lib/backgroundHooks/useWatchClipboard.ts
@@ -108,6 +108,12 @@ export const useWatchClipboard = () => {
 
 		const handleYes = async () => {
 			try {
+				// Noffer needs spend-source keys to fetch invoices — Send parses with selectedSource
+				if (classification === InputClassification.NOFFER) {
+					history.push({ pathname: "/send", state: { input: value } });
+					return;
+				}
+
 				const parsed = await parseBitcoinInput(value, classification);
 
 
@@ -130,7 +136,6 @@ export const useWatchClipboard = () => {
 				history.push({
 					pathname: "/send",
 					state: {
-						// pass the input string as opposed to parsed object because in the case of noffer it needs the selected source
 						input: parsed.data
 					}
 				});


### PR DESCRIPTION
Clipboard never passed spend-source keys to noffer parse, so confirm always failed despite having funded sources. Skip parse for noffers and navigate with the raw string; Send already parses with selectedSource.keys.